### PR TITLE
Corrigir erro de sintaxe no css

### DIFF
--- a/analise_erro_build.md
+++ b/analise_erro_build.md
@@ -1,0 +1,162 @@
+# Análise do Erro de Build - Next.js
+
+## Erro Identificado
+
+O erro que você está enfrentando é um **erro de sintaxe CSS** no arquivo `src/app/globals.css` na linha 18, coluna 14:
+
+```
+SyntaxError: Unexpected token, expected ";" (18:14)
+```
+
+## Possíveis Causas
+
+### 1. **Sintaxe CSS Inválida**
+O erro indica que há um problema de sintaxe CSS na linha 18 do arquivo `globals.css`. Os erros mais comuns incluem:
+
+- **Ponto e vírgula ausente** (`;`) no final de uma propriedade CSS
+- **Chaves mal fechadas** (`{` ou `}`)
+- **Dois pontos ausentes** (`:`) entre propriedade e valor
+- **Caracteres especiais inválidos** ou caracteres invisíveis
+- **Comentários CSS mal formatados** (`/* */`)
+
+### 2. **Problemas com Tailwind CSS**
+Se você estiver usando Tailwind CSS, verifique se as diretivas estão corretas:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### 3. **Codificação de Caracteres**
+Caracteres especiais ou codificação incorreta podem causar problemas de parsing.
+
+## Soluções Recomendadas
+
+### Solução 1: Verificar a Linha 18
+1. Abra o arquivo `src/app/globals.css`
+2. Vá até a linha 18
+3. Verifique se há:
+   - Ponto e vírgula no final da propriedade CSS
+   - Sintaxe correta da propriedade
+   - Chaves adequadamente fechadas
+
+### Solução 2: Exemplo de globals.css Correto
+Aqui está um exemplo de arquivo `globals.css` funcional para Next.js:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  color: rgb(var(--foreground-rgb));
+  background: linear-gradient(
+      to bottom,
+      transparent,
+      rgb(var(--background-end-rgb))
+    )
+    rgb(var(--background-start-rgb));
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  html {
+    color-scheme: dark;
+  }
+}
+```
+
+### Solução 3: Recriar o Arquivo
+Se o problema persistir, considere:
+
+1. **Fazer backup** do conteúdo atual do `globals.css`
+2. **Deletar** o arquivo atual
+3. **Criar um novo** arquivo `globals.css` com conteúdo básico
+4. **Adicionar** gradualmente o conteúdo original
+
+### Solução 4: Verificar Configurações
+Verifique se os seguintes arquivos estão configurados corretamente:
+
+#### `tailwind.config.js`
+```javascript
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      backgroundImage: {
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+    },
+  },
+  plugins: [],
+}
+```
+
+#### `postcss.config.js`
+```javascript
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}
+```
+
+## Passos para Resolução
+
+1. **Identifique o erro exato** na linha 18 do `globals.css`
+2. **Corrija a sintaxe** CSS (adicione `;`, `{}`, etc.)
+3. **Teste localmente** com `npm run dev`
+4. **Faça commit** das alterações
+5. **Redeploy** no Vercel
+
+## Comandos Úteis
+
+```bash
+# Verificar erros de sintaxe localmente
+npm run build
+
+# Executar em modo desenvolvimento
+npm run dev
+
+# Limpar cache do Next.js
+npm run dev -- --reset-cache
+```
+
+## Observações Importantes
+
+- O erro está relacionado ao **parsing CSS**, não ao código JavaScript
+- O problema ocorre durante o **build process** do Next.js
+- A linha 18 é especificamente onde o parser encontrou o erro
+- Certifique-se de que não há **caracteres invisíveis** ou **codificação incorreta**
+
+## Próximos Passos
+
+1. Verifique o arquivo `src/app/globals.css` na linha 18
+2. Corrija qualquer erro de sintaxe CSS
+3. Teste o build localmente antes de fazer deploy
+4. Se o problema persistir, considere compartilhar o conteúdo do arquivo `globals.css` para análise mais detalhada

--- a/globals_corrigido.css
+++ b/globals_corrigido.css
@@ -1,0 +1,28 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Estilos básicos */
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/globals_final.css
+++ b/globals_final.css
@@ -1,0 +1,31 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Reset básico */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  line-height: 1.6;
+  font-size: 16px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Add `analise_erro_build.md` to explain and provide solutions for a CSS syntax error preventing the Next.js build.